### PR TITLE
Bugfix: FE job app status not displaying

### DIFF
--- a/backend/models/Job.js
+++ b/backend/models/Job.js
@@ -20,7 +20,7 @@ const Job = sequelize => {
         },
       },
     },
-    status: {
+    jobStatus: {
       type: DataTypes.STRING,
       isIn: [APPLICATION_STATUSES],
     },

--- a/backend/utils/constants.js
+++ b/backend/utils/constants.js
@@ -24,7 +24,7 @@ export const DUMMY_TABLE_DATA = [
     date: "10-24-2022",
     skills: "C#, .NET, MS SQL Server 2005",
     contacts: "Thomas Timpson",
-    status: "Accepted Offer",
+    jobStatus: "Offer (Accepted)",
   },
   {
     id: 1,
@@ -33,7 +33,7 @@ export const DUMMY_TABLE_DATA = [
     date: "10-25-2022",
     skills: "DFS, single letter variable names",
     contacts: "Leslie Ivanov",
-    status: "Phone Interview",
+    jobStatus: "Phone Interview",
   },
   {
     id: 2,
@@ -42,7 +42,7 @@ export const DUMMY_TABLE_DATA = [
     date: "10-26-2022",
     skills: "Go, Docker, Kubernetes",
     contacts: "Nathan Perkins",
-    status: "Rejected Offer",
+    jobStatus: "Offer (Rejected)",
   },
   {
     id: 3,
@@ -51,6 +51,6 @@ export const DUMMY_TABLE_DATA = [
     date: "10-25-2022",
     skills: "AWS, React, Java",
     contacts: "Alex Deatherage",
-    status: "Applied",
+    jobStatus: "Applied",
   },
 ];

--- a/frontend/src/pages/Jobs/AddJobForm.js
+++ b/frontend/src/pages/Jobs/AddJobForm.js
@@ -8,7 +8,7 @@ import JobForm from "pages/Jobs/JobForm";
  * This will move to its own page eventually. Probably.
  */
 const AddJobForm = ({ handleCreateRow }) => {
-  const heading = "Add New Job";
+  const heading = "New Job Application";
   const formType = "add";
   return (
     <Formik

--- a/frontend/src/pages/Jobs/EditJobForm.js
+++ b/frontend/src/pages/Jobs/EditJobForm.js
@@ -10,7 +10,7 @@ import JobForm from "pages/Jobs/JobForm";
  * can update single row??
  */
 const EditJobForm = ({ handleUpdateRow, selectedRow }) => {
-  const heading = "Edit Job";
+  const heading = "Edit Job Application";
   const formType = "edit";
   return (
     <Formik
@@ -18,7 +18,7 @@ const EditJobForm = ({ handleUpdateRow, selectedRow }) => {
         company: selectedRow?.company ?? "",
         position: selectedRow?.position ?? "",
         date: selectedRow?.date ?? dayjs(), // Same as date.now().
-        jobStatus: selectedRow?.status ?? APPLICATION_STATUSES.applied,
+        jobStatus: selectedRow?.jobStatus ?? APPLICATION_STATUSES.applied,
         skills: selectedRow?.skills ?? "",
         contacts: selectedRow?.contacts ?? "",
       }}

--- a/frontend/src/pages/Jobs/JobsTable.js
+++ b/frontend/src/pages/Jobs/JobsTable.js
@@ -93,7 +93,7 @@ const JobsTable = ({ rows, setRows }) => {
     },
     {
       field: "jobStatus",
-      headerName: APPLICATION_FIELDS.status,
+      headerName: APPLICATION_FIELDS.jobStatus,
       width: JOB_TABLE_COLUMN_STYLES.CELL_SM,
     },
     {
@@ -129,7 +129,7 @@ const JobsTable = ({ rows, setRows }) => {
           variant="contained"
           disableElevation
         >
-          Add
+          NEW
         </Button>
         <Drawer
           anchor="right"


### PR DESCRIPTION
Update some data variable names:
- Some FE areas did not play nicely with key named "status" because there were other properties named "status".
- Updated in BE as well.